### PR TITLE
sepolicy: Add rules for misc_writer_system and themed_bootanimation

### DIFF
--- a/private/compat/26.0/26.0.ignore.cil
+++ b/private/compat/26.0/26.0.ignore.cil
@@ -118,6 +118,10 @@
     mediaextractor_update_service
     mediaprovider_tmpfs
     metadata_file
+    misc_writer
+    misc_writer_exec
+    misc_writer_prop
+    misc_writer_tmpfs
     mnt_product_file
     mnt_vendor_file
     netd_stable_secret_prop

--- a/private/compat/27.0/27.0.ignore.cil
+++ b/private/compat/27.0/27.0.ignore.cil
@@ -107,6 +107,10 @@
     mediaswcodec_exec
     mediaswcodec_tmpfs
     metadata_file
+    misc_writer
+    misc_writer_exec
+    misc_writer_prop
+    misc_writer_tmpfs
     mnt_product_file
     mnt_vendor_file
     network_stack

--- a/private/compat/28.0/28.0.ignore.cil
+++ b/private/compat/28.0/28.0.ignore.cil
@@ -95,6 +95,10 @@
     mediaswcodec
     mediaswcodec_exec
     mediaswcodec_tmpfs
+    misc_writer
+    misc_writer_exec
+    misc_writer_prop
+    misc_writer_tmpfs
     mnt_product_file
     network_stack
     network_stack_service

--- a/private/file_contexts
+++ b/private/file_contexts
@@ -328,6 +328,10 @@
 /system/bin/notify_traceur\.sh       u:object_r:notify_traceur_exec:s0
 /system/bin/migrate_legacy_obb_data\.sh u:object_r:migrate_legacy_obb_data_exec:s0
 
+# Themed bootanimation
+/system/bin/misc_writer_system                           u:object_r:misc_writer_exec:s0
+/system/bin/themed_bootanimation                         u:object_r:misc_writer_exec:s0
+
 #############################
 # Vendor files
 #

--- a/private/misc_writer.te
+++ b/private/misc_writer.te
@@ -1,0 +1,1 @@
+init_daemon_domain(misc_writer)

--- a/private/property_contexts
+++ b/private/property_contexts
@@ -85,6 +85,9 @@ test.sys.boot.reason    u:object_r:test_boot_reason_prop:s0
 sys.lmk.                u:object_r:system_lmk_prop:s0
 sys.trace.              u:object_r:system_trace_prop:s0
 
+# Dark bootanimation
+ro.boot.theme           u:object_r:misc_writer_prop:s0
+
 # Boolean property set by system server upon boot indicating
 # if device owner is provisioned.
 ro.device_owner         u:object_r:device_logging_prop:s0

--- a/public/bootanim.te
+++ b/public/bootanim.te
@@ -40,3 +40,5 @@ allow bootanim system_file:dir r_dir_perms;
 # Read ro.boot.bootreason b/30654343
 get_prop(bootanim, bootloader_boot_reason_prop)
 
+# Read dark bootanimation state
+get_prop(bootanim, misc_writer_prop)

--- a/public/domain.te
+++ b/public/domain.te
@@ -610,6 +610,7 @@ neverallow {
   -uncrypt
   -update_engine
   -vendor_init
+  -misc_writer
   -vendor_misc_writer
   -vold
   -recovery
@@ -966,6 +967,7 @@ full_treble_only(`
         -crash_dump_exec
         -netutils_wrapper_exec
         userdebug_or_eng(`-tcpdump_exec')
+        -misc_writer_exec
     }:file { entrypoint execute execute_no_trans };
 ')
 

--- a/public/misc_writer.te
+++ b/public/misc_writer.te
@@ -1,0 +1,19 @@
+# misc_writer
+type misc_writer, coredomain, domain;
+type misc_writer_exec, system_file_type, exec_type, file_type;
+type misc_writer_prop, property_type;
+
+# Raw writes to misc_block_device
+allow misc_writer misc_block_device:blk_file rw_file_perms;
+allow misc_writer block_device:dir r_dir_perms;
+
+# Silence the denial when calling libfstab's ReadDefaultFstab.
+dontaudit misc_writer proc_cmdline:file read;
+dontaudit misc_writer metadata_file:dir search;
+
+# Read files in /sys
+r_dir_file(misc_writer, sysfs_dt_firmware_android)
+
+# Boot prop
+get_prop(misc_writer, misc_writer_prop)
+set_prop(misc_writer, misc_writer_prop)

--- a/public/property.te
+++ b/public/property.te
@@ -436,6 +436,7 @@ compatible_property_only(`
     -logpersistd_logging_prop
     -lowpan_prop
     -lpdumpd_prop
+    -misc_writer_prop
     -mmc_prop
     -net_dns_prop
     -net_radio_prop

--- a/public/property_contexts
+++ b/public/property_contexts
@@ -414,3 +414,6 @@ ro.surface_flinger.support_kernel_idle_timer u:object_r:exported_default_prop:s0
 ro.surface_flinger.use_smart_90_for_video u:object_r:exported_default_prop:s0 exact bool
 ro.surface_flinger.color_space_agnostic_dataspace u:object_r:exported_default_prop:s0 exact int
 ro.surface_flinger.refresh_rate_switching u:object_r:exported_default_prop:s0 exact bool
+
+# Dark bootanimation
+ro.boot.theme u:object_r:misc_writer_prop:s0 exact string


### PR DESCRIPTION
Change-Id: I399bb5fd442788ba503b19ccdf08176fd8da06be
Co-authored-by: Dyneteve <dyneteve@pixelexperience.org>
 * Needed for MTK sepolicy and others