### PR TITLE
prebuilts: Sync rules with reference

### DIFF
--- a/prebuilts/api/31.0/private/property.te
+++ b/prebuilts/api/31.0/private/property.te
@@ -47,7 +47,7 @@ system_internal_prop(ctl_odsign_prop)
 treble_sysprop_neverallow(`
 
 enforce_sysprop_owner(`
-  neverallow domain {
+  neverallow { domain -init -dumpstate }{
     property_type
     -system_property_type
     -product_property_type

--- a/prebuilts/api/31.0/private/system_app.te
+++ b/prebuilts/api/31.0/private/system_app.te
@@ -173,6 +173,9 @@ get_prop(system_app, oem_unlock_prop)
 # Allow system apps to act as Perfetto producers.
 perfetto_producer(system_app)
 
+# allow system apps to read qemu.hw.mainkeys
+get_prop(system_app, qemu_hw_prop)
+
 ###
 ### Neverallow rules
 ###

--- a/prebuilts/api/31.0/public/app.te
+++ b/prebuilts/api/31.0/public/app.te
@@ -534,7 +534,8 @@ neverallow appdomain
     proc:dir_file_class_set write;
 
 # Access to syslog(2) or /proc/kmsg.
-neverallow appdomain kernel:system { syslog_read syslog_mod syslog_console };
+neverallow { appdomain -system_app -shell -platform_app -priv_app }
+    kernel:system { syslog_read syslog_mod syslog_console };
 
 # SELinux is not an API for apps to use
 neverallow { appdomain -shell } *:security { compute_av check_context };


### PR DESCRIPTION
* Some recent updates to sepolicy rules forgot to include updating prebuilts
* raven expects these to always match otherwise build will fail with error
  stating as such.

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>