### PR TITLE
sepolicy: Allow init to tune more dirty writeback parameters

### DIFF
--- a/prebuilts/api/29.0/private/genfs_contexts
+++ b/prebuilts/api/29.0/private/genfs_contexts
@@ -67,7 +67,9 @@ genfscon proc /sys/kernel/sched_wakeup_granularity_ns u:object_r:proc_sched:s0
 genfscon proc /sys/kernel/sysrq u:object_r:proc_sysrq:s0
 genfscon proc /sys/kernel/usermodehelper u:object_r:usermodehelper:s0
 genfscon proc /sys/net u:object_r:proc_net:s0
+genfscon proc /sys/vm/dirty_background_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_background_ratio u:object_r:proc_dirty:s0
+genfscon proc /sys/vm/dirty_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_expire_centisecs u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/extra_free_kbytes u:object_r:proc_extra_free_kbytes:s0
 genfscon proc /sys/vm/max_map_count u:object_r:proc_max_map_count:s0

--- a/prebuilts/api/30.0/private/genfs_contexts
+++ b/prebuilts/api/30.0/private/genfs_contexts
@@ -69,7 +69,9 @@ genfscon proc /sys/kernel/sched_wakeup_granularity_ns u:object_r:proc_sched:s0
 genfscon proc /sys/kernel/sysrq u:object_r:proc_sysrq:s0
 genfscon proc /sys/kernel/usermodehelper u:object_r:usermodehelper:s0
 genfscon proc /sys/net u:object_r:proc_net:s0
+genfscon proc /sys/vm/dirty_background_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_background_ratio u:object_r:proc_dirty:s0
+genfscon proc /sys/vm/dirty_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_expire_centisecs u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/extra_free_kbytes u:object_r:proc_extra_free_kbytes:s0
 genfscon proc /sys/vm/max_map_count u:object_r:proc_max_map_count:s0

--- a/prebuilts/api/31.0/private/genfs_contexts
+++ b/prebuilts/api/31.0/private/genfs_contexts
@@ -75,7 +75,9 @@ genfscon proc /sys/kernel/sched_wakeup_granularity_ns u:object_r:proc_sched:s0
 genfscon proc /sys/kernel/sysrq u:object_r:proc_sysrq:s0
 genfscon proc /sys/kernel/usermodehelper u:object_r:usermodehelper:s0
 genfscon proc /sys/net u:object_r:proc_net:s0
+genfscon proc /sys/vm/dirty_background_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_background_ratio u:object_r:proc_dirty:s0
+genfscon proc /sys/vm/dirty_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_expire_centisecs u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/extra_free_kbytes u:object_r:proc_extra_free_kbytes:s0
 genfscon proc /sys/vm/max_map_count u:object_r:proc_max_map_count:s0

--- a/prebuilts/api/32.0/private/genfs_contexts
+++ b/prebuilts/api/32.0/private/genfs_contexts
@@ -75,7 +75,9 @@ genfscon proc /sys/kernel/sched_wakeup_granularity_ns u:object_r:proc_sched:s0
 genfscon proc /sys/kernel/sysrq u:object_r:proc_sysrq:s0
 genfscon proc /sys/kernel/usermodehelper u:object_r:usermodehelper:s0
 genfscon proc /sys/net u:object_r:proc_net:s0
+genfscon proc /sys/vm/dirty_background_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_background_ratio u:object_r:proc_dirty:s0
+genfscon proc /sys/vm/dirty_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_expire_centisecs u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/extra_free_kbytes u:object_r:proc_extra_free_kbytes:s0
 genfscon proc /sys/vm/max_map_count u:object_r:proc_max_map_count:s0

--- a/prebuilts/api/33.0/private/genfs_contexts
+++ b/prebuilts/api/33.0/private/genfs_contexts
@@ -79,7 +79,9 @@ genfscon proc /sys/kernel/unprivileged_bpf_ u:object_r:proc_bpf:s0
 genfscon proc /sys/kernel/usermodehelper u:object_r:usermodehelper:s0
 genfscon proc /sys/net u:object_r:proc_net:s0
 genfscon proc /sys/net/core/bpf_ u:object_r:proc_bpf:s0
+genfscon proc /sys/vm/dirty_background_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_background_ratio u:object_r:proc_dirty:s0
+genfscon proc /sys/vm/dirty_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_expire_centisecs u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/extra_free_kbytes u:object_r:proc_extra_free_kbytes:s0
 genfscon proc /sys/vm/max_map_count u:object_r:proc_max_map_count:s0

--- a/prebuilts/api/34.0/private/genfs_contexts
+++ b/prebuilts/api/34.0/private/genfs_contexts
@@ -78,7 +78,9 @@ genfscon proc /sys/kernel/unprivileged_bpf_ u:object_r:proc_bpf:s0
 genfscon proc /sys/kernel/usermodehelper u:object_r:usermodehelper:s0
 genfscon proc /sys/net u:object_r:proc_net:s0
 genfscon proc /sys/net/core/bpf_ u:object_r:proc_bpf:s0
+genfscon proc /sys/vm/dirty_background_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_background_ratio u:object_r:proc_dirty:s0
+genfscon proc /sys/vm/dirty_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_expire_centisecs u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/extra_free_kbytes u:object_r:proc_extra_free_kbytes:s0
 genfscon proc /sys/vm/max_map_count u:object_r:proc_max_map_count:s0

--- a/private/genfs_contexts
+++ b/private/genfs_contexts
@@ -79,7 +79,9 @@ genfscon proc /sys/kernel/unprivileged_bpf_ u:object_r:proc_bpf:s0
 genfscon proc /sys/kernel/usermodehelper u:object_r:usermodehelper:s0
 genfscon proc /sys/net u:object_r:proc_net:s0
 genfscon proc /sys/net/core/bpf_ u:object_r:proc_bpf:s0
+genfscon proc /sys/vm/dirty_background_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_background_ratio u:object_r:proc_dirty:s0
+genfscon proc /sys/vm/dirty_bytes u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/dirty_expire_centisecs u:object_r:proc_dirty:s0
 genfscon proc /sys/vm/extra_free_kbytes u:object_r:proc_extra_free_kbytes:s0
 genfscon proc /sys/vm/max_map_count u:object_r:proc_max_map_count:s0


### PR DESCRIPTION
Needed after system/core change ID I22f9ec9010dd028710a1a5c2e3d26d8444a4c914

"init.rc: tune dirty data writebacks"
_____

See https://github.com/crdroidandroid/android_system_core/commit/1a053ca0d3790aae43df8804734482be65f49ba0