### PR TITLE
Allow adb root on user builds

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -699,7 +699,10 @@ precompiled_se_policy_binary {
     dist: {
         targets: ["base-sepolicy-files-for-mapping"],
     },
-    permissive_domains_on_user_builds: ["backuptool"],
+    permissive_domains_on_user_builds: [
+        "backuptool",
+        "su",
+    ],
 }
 
 // policy for recovery
@@ -737,6 +740,7 @@ se_policy_binary {
     permissive_domains_on_user_builds: [
         "backuptool",
         "recovery",
+        "su",
     ],
 }
 
@@ -788,6 +792,7 @@ se_policy_binary {
     dist: {
         targets: ["base-sepolicy-files-for-mapping"],
     },
+    permissive_domains_on_user_builds: ["su"],
 }
 
 se_policy_conf {

--- a/build/soong/compat_cil.go
+++ b/build/soong/compat_cil.go
@@ -165,7 +165,7 @@ func (f *compatTestModule) createCompatTestModule(ctx android.LoadHookContext, v
 		Srcs:              srcs,
 		Ignore_neverallow: proptools.BoolPtr(true),
 		Installable:       proptools.BoolPtr(false),
-		Permissive_domains_on_user_builds: []string{"backuptool"},
+		Permissive_domains_on_user_builds: []string{"backuptool", "su"},
 	})
 }
 

--- a/prebuilts/api/34.0/private/adbd.te
+++ b/prebuilts/api/34.0/private/adbd.te
@@ -7,10 +7,8 @@ init_daemon_domain(adbd)
 
 domain_auto_trans(adbd, shell_exec, shell)
 
-userdebug_or_eng(`
-  allow adbd self:process setcurrent;
-  allow adbd su:process dyntransition;
-')
+allow adbd self:process setcurrent;
+allow adbd su:process dyntransition;
 
 # When 'adb shell' is executed in recovery mode, adbd explicitly
 # switches into shell domain using setcon() because the shell executable
@@ -231,7 +229,6 @@ allow adbd apex_info_file:file r_file_perms;
 ###
 
 # No transitions from adbd to non-shell, non-crash_dump domains. adbd only ever
-# transitions to the shell domain (except when it crashes). In particular, we
-# never want to see a transition from adbd to su (aka "adb root")
+# transitions to the shell domain (except when it crashes).
 neverallow adbd { domain -crash_dump -shell }:process transition;
-neverallow adbd { domain userdebug_or_eng(`-su') recovery_only(`-shell') }:process dyntransition;
+neverallow adbd { domain -su recovery_only(`-shell') }:process dyntransition;

--- a/prebuilts/api/34.0/private/su.te
+++ b/prebuilts/api/34.0/private/su.te
@@ -1,6 +1,6 @@
-userdebug_or_eng(`
-  typeattribute su coredomain;
+typeattribute su coredomain;
 
+userdebug_or_eng(`
   domain_auto_trans(shell, su_exec, su)
   # Allow dumpstate to call su on userdebug / eng builds to collect
   # additional information.
@@ -22,9 +22,6 @@ userdebug_or_eng(`
   # Put the virtmgr command into its domain.
   domain_auto_trans(su, virtualizationmanager_exec, virtualizationmanager)
 
-  # su is also permissive to permit setenforce.
-  permissive su;
-
   app_domain(su)
 
   # Do not audit accesses to keystore2 namespace for the su domain.
@@ -33,3 +30,6 @@ userdebug_or_eng(`
   # Allow root to set MTE permissive mode.
   set_prop(su, permissive_mte_prop);
 ')
+
+# su is also permissive to permit setenforce.
+permissive su;

--- a/private/adbd.te
+++ b/private/adbd.te
@@ -8,13 +8,9 @@ init_daemon_domain(adbd)
 
 domain_auto_trans(adbd, shell_exec, shell)
 
-# Allow adb to setcon() to tradeinmode.
 allow adbd self:process setcurrent;
+allow adbd su:process dyntransition;
 allow adbd adbd_tradeinmode:process dyntransition;
-
-userdebug_or_eng(`
-  allow adbd su:process dyntransition;
-')
 
 # When 'adb shell' is executed in recovery mode, adbd explicitly
 # switches into shell domain using setcon() because the shell executable
@@ -215,16 +211,6 @@ allow adbd shell_test_data_file:lnk_file create_file_perms;
 ###
 
 # No transitions from adbd to non-shell, non-crash_dump domains. adbd only ever
-# transitions to the shell or tradeinmode domain (except when it crashes). In
-# particular, we never want to see a transition from adbd to su (aka "adb root")
+# transitions to the shell or tradeinmode domain (except when it crashes).
 neverallow adbd { domain -crash_dump -shell -adbd_tradeinmode }:process transition;
-neverallow adbd {
-    domain
-    userdebug_or_eng(`-su')
-    recovery_only(`-shell')
-    -adbd_tradeinmode
-}:process dyntransition;
-
-# Only init is allowed to enter the adbd domain via exec()
-neverallow { domain -init } adbd:process transition;
-neverallow * adbd:process dyntransition;
+neverallow adbd { domain -su recovery_only(`-shell') -adbd_tradeinmode }:process dyntransition;

--- a/private/su.te
+++ b/private/su.te
@@ -1,6 +1,6 @@
-userdebug_or_eng(`
-  typeattribute su coredomain;
+typeattribute su coredomain;
 
+userdebug_or_eng(`
   domain_auto_trans(shell, su_exec, su)
   # Allow dumpstate to call su on userdebug / eng builds to collect
   # additional information.
@@ -22,9 +22,6 @@ userdebug_or_eng(`
   # Allow accessing virtualization (e.g. via the vm command) - ensures virtmgr runs in its
   # own domain.
   virtualizationservice_use(su)
-
-  # su is also permissive to permit setenforce.
-  permissive su;
 
   app_domain(su)
 
@@ -133,3 +130,6 @@ userdebug_or_eng(`
   typeattribute su hal_wifi_hostapd_client;
   typeattribute su hal_wifi_supplicant_client;
 ')
+
+# su is also permissive to permit setenforce.
+permissive su;


### PR DESCRIPTION
Also make su domain permissive for adb root. Updater needs those in order to finish the update successfully. Tested over and over on Pixel 8 Pro
Ref. code: https://github.com/crdroidandroid/android_packages_apps_Updater/blob/59b1a515109dd184232dc89b8abd0e84b8f9e701/push-update.sh#L19