### PR TITLE
!fixup: Make su domain permissive on user builds

### DIFF
--- a/contexts/Android.bp
+++ b/contexts/Android.bp
@@ -434,6 +434,7 @@ se_policy_binary {
     name: "plat_precompiled_sepolicy",
     srcs: [":plat_sepolicy.cil"],
     installable: false,
+    permissive_domains_on_user_builds: ["su"],
 }
 
 // Use plat_precompiled_sepolicy instead of precompiled_sepolicy because


### PR DESCRIPTION
Needed for user builds since android-16.0.0_r3 (QPR1 ?)
Could also be merged into the original commit and rebased.